### PR TITLE
Remove checkout cancel URL which should not be included for integration type embedded checkout

### DIFF
--- a/MiaSample/MiaSample/Managers/RequestManager.swift
+++ b/MiaSample/MiaSample/Managers/RequestManager.swift
@@ -67,7 +67,6 @@ public class RequestManager {
         case .embeddedCheckout:
             checkoutDict.setValue(IntegrationType.embeddedCheckout.rawValue, forKey: "integrationType")
             checkoutDict.setValue(ipAddress, forKey: "url")
-            checkoutDict.setValue(constant.testCancelUrl, forKey: "cancelURL")
         case .hostedPaymentWindow:
             checkoutDict.setValue(IntegrationType.hostedPaymentWindow.rawValue, forKey: "integrationType")
             checkoutDict.setValue(constant.testReturnUrl, forKey: "returnURL")


### PR DESCRIPTION
With the checkout cancel URL set, embedded checkout fails as described in issue #11.

This change fixes the problem described in said issue.